### PR TITLE
Fix compilation errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "lib": ["dom"]
   },
   "include": [
     "ts/**/*.ts",


### PR DESCRIPTION
You have to do this because the types for three.js and aframe are not compiled and do not define what HTMLElement, etc. are; you need to ask tsc to load those intrinsic definitions for you when compiling.